### PR TITLE
feat: Add revalidation paths for skill tree actions and sign-up process

### DIFF
--- a/actions/join-skilltree-action.ts
+++ b/actions/join-skilltree-action.ts
@@ -18,6 +18,8 @@ export async function joinSkillTreeAction(id: string) {
   const data = await response.json();
 
   revalidatePath(`/community/${id}`);
+  revalidatePath("/dashboard");
+  revalidatePath(`/community/${id}/members`);
 
   if (!response.ok) {
     return { ok: false, message: data.message || "Something went wrong" };

--- a/actions/leave-skilltree-action.ts
+++ b/actions/leave-skilltree-action.ts
@@ -18,9 +18,12 @@ export async function leaveSkillTreeAction(id: string) {
   const data = await response.json();
 
   revalidatePath(`/community/${id}`);
+  revalidatePath("/dashboard");
+  revalidatePath(`/community/${id}/members`);
 
   if (!response.ok) {
     return { ok: false, message: data.message || "Something went wrong" };
   }
+
   return { ok: true, message: data.message, status: response.status };
 }

--- a/actions/remove-user-from-skilltree.ts
+++ b/actions/remove-user-from-skilltree.ts
@@ -25,7 +25,9 @@ export async function removeUserFromSkillTree(
   }
 
   const message = data.message as string;
-  revalidatePath(`/community/[id]`);
+  revalidatePath(`/community/${skillTreeId}`);
+  revalidatePath(`/community/${skillTreeId}/members`);
+  revalidatePath("/dashboard");
 
   return { ok: true, message };
 }

--- a/actions/signup-action.ts
+++ b/actions/signup-action.ts
@@ -3,6 +3,7 @@
 import { cookies } from "next/headers";
 import { TSignUpResponse } from "./types";
 import { APIResponse } from "@/types";
+import { revalidatePath } from "next/cache";
 
 export async function signUpAction(form: {
   name: string;
@@ -36,6 +37,8 @@ export async function signUpAction(form: {
     secure: process.env.NODE_ENV === "production",
     maxAge: 60 * 60 * 24 * 7, // 1 week
   });
+
+  revalidatePath("/(default)", "layout");
 
   return { ok: true, message: signUpData };
 }


### PR DESCRIPTION
This pull request updates several action handlers to ensure that relevant pages are revalidated after user actions, improving data consistency across the dashboard and community pages. The changes primarily add calls to `revalidatePath` in various user-related actions and update the paths to reflect dynamic community IDs.

**Path revalidation improvements:**

* Added `revalidatePath("/dashboard")` and `revalidatePath(`/community/${id}/members`)` to both `joinSkillTreeAction` and `leaveSkillTreeAction` to ensure the dashboard and community member lists reflect membership changes. [[1]](diffhunk://#diff-71549341f81ea55b0f3c957e0a9a86fe60f15875e922c26a167ecd65c4aebf94R21-R22) [[2]](diffhunk://#diff-e820f0a24db0064c6c450bbeaa393571c2df2858fe5fbdfb391b709c25ee7fe1R21-R27)
* Updated `removeUserFromSkillTree` to revalidate the specific community and its members page using the correct `skillTreeId` variable, and also revalidate the dashboard.
* In `signUpAction`, added `revalidatePath("/(default)", "layout")` to ensure the default layout is refreshed after signup.
* Imported `revalidatePath` from `next/cache` in `signup-action.ts` to support the new revalidation logic.